### PR TITLE
fix: remove dangling namespaces from system tests

### DIFF
--- a/vars/test.groovy
+++ b/vars/test.groovy
@@ -14,11 +14,12 @@ def call(Map parameters = [:]) {
 
     container(name: 'maven') {
         git 'https://github.com/syndesisio/syndesis-system-tests.git'
-        def mavenOptions = namespace.isEmpty() ? "" : "-Dnamespace.use.existing=${namespace} -Denv.init.enabled=${envInitEnabled}"
+        def namespaceOption = namespace.isEmpty() ? "" : "-Dnamespace.use.existing=${namespace} -Denv.init.enabled=${envInitEnabled}"
+        def mavenOptions = "${namespaceOption} -Dnamespace.destroy.enabled=true"
 
         //TODO: Fix usingLocalBinaries as withEnv isn't currently supported. Then use it instead of this:
         sh """
-	env
+        env
         mkdir -p \${HOME}/bin
         export PATH=\${PATH}:\${HOME}/bin
         mvn clean install -U ${mavenOptions}

--- a/vars/test.groovy
+++ b/vars/test.groovy
@@ -14,8 +14,9 @@ def call(Map parameters = [:]) {
 
     container(name: 'maven') {
         git 'https://github.com/syndesisio/syndesis-system-tests.git'
-        def namespaceOption = namespace.isEmpty() ? "" : "-Dnamespace.use.existing=${namespace} -Denv.init.enabled=${envInitEnabled}"
-        def mavenOptions = "${namespaceOption} -Dnamespace.destroy.enabled=true"
+        def namespaceOption = namespace.isEmpty() ? "-Dnamespace.destroy.enabled=true" : "-Dnamespace.use.existing=${namespace} -Denv.init.enabled=${envInitEnabled}"
+
+        def mavenOptions = "${namespaceOption}"
 
         //TODO: Fix usingLocalBinaries as withEnv isn't currently supported. Then use it instead of this:
         sh """


### PR DESCRIPTION
Adds `-Dnamespace.destroy.enabled=true` which according to the
[Arquillian Cube documentation](http://arquillian.org/arquillian-cube/#_namespaces)
should delete the dangling namespace.