### PR TITLE
fix(build): try without the .m2-ro mount

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ node {
         stage 'Building'
         slave {
             withOpenshift {
-                withMaven(mavenImage: "openjdk:8", serviceAccount: "builder") {
+                withMaven(mavenImage: "openjdk:8", serviceAccount: "builder", mavenSettingsXmlSecret: 'm2-settings') {
                     inside {
                         stage('Prepare Environment') {
                             createEnvironment(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,6 @@ def cases = [
     [
         mavenSettings: [mavenImage: "openjdk:8", serviceAccount: "builder", mavenSettingsXmlSecret: 'm2-settings']
     ], [
-
         mavenSettings: [mavenImage: "openjdk:8", serviceAccount: "builder"]
     ]
 ]
@@ -12,25 +11,25 @@ node {
     library identifier: "syndesis-pipeline-library@${env.BRANCH_NAME}", retriever: workspaceRetriever("${WORKSPACE}")
     inNamespace(cloud:'openshift', prefix: 'e2e') {
 
-        stage('Building') {
-            slave {
-                withOpenshift {
-                    for (i = 0; i < cases.size; i++) {
+        stage('Prepare Environment') {
+            createEnvironment(
+                cloud: 'openshift', name: "${KUBERNETES_NAMESPACE}",
+                environmentSetupScriptUrl: 'https://raw.githubusercontent.com/syndesisio/syndesis-system-tests/master/src/test/resources/setup.sh',
+                environmentTeardownScriptUrl: 'https://raw.githubusercontent.com/syndesisio/syndesis-system-tests/master/src/test/resources/teardown.sh',
+                waitForServiceList: ['syndesis-rest', 'syndesis-ui', 'syndesis-keycloak', 'syndesis-verifier'],
+                waitTimeout: 600000L,
+                namespaceDestroyEnabled: false,
+                namespaceCleanupEnabled: false
+            )
+        }
+
+        for (i = 0; i < cases.size; i++) {
+            stage("Building [case:$i]") {
+                slave {
+                    withOpenshift {
                         withMaven(cases[i].mavenSettings) {
                             inside {
-                                stage('Prepare Environment') {
-                                    createEnvironment(
-                                        cloud: 'openshift', name: "${KUBERNETES_NAMESPACE}",
-                                        environmentSetupScriptUrl: 'https://raw.githubusercontent.com/syndesisio/syndesis-system-tests/master/src/test/resources/setup.sh',
-                                        environmentTeardownScriptUrl: 'https://raw.githubusercontent.com/syndesisio/syndesis-system-tests/master/src/test/resources/teardown.sh',
-                                        waitForServiceList: ['syndesis-rest', 'syndesis-ui', 'syndesis-keycloak', 'syndesis-verifier'],
-                                        waitTimeout: 600000L,
-                                        namespaceDestroyEnabled: false,
-                                        namespaceCleanupEnabled: false
-                                    )
-                                }
-
-                                stage('System Tests') {
+                                stage("System Tests [case:$i]") {
                                     def testingNamespace = currentNamespace()
                                     test(component: 'syndesis-pipeline-library', envInitEnabled: false, namespace: "${KUBERNETES_NAMESPACE}", serviceAccount: 'jenkins')
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,28 +1,40 @@
+def cases = [
+    [
+        mavenSettings: [mavenImage: "openjdk:8", serviceAccount: "builder", mavenSettingsXmlSecret: 'm2-settings']
+    ], [
+
+        mavenSettings: [mavenImage: "openjdk:8", serviceAccount: "builder"]
+    ]
+]
+
 node {
     checkout scm
     library identifier: "syndesis-pipeline-library@${env.BRANCH_NAME}", retriever: workspaceRetriever("${WORKSPACE}")
     inNamespace(cloud:'openshift', prefix: 'e2e') {
 
-        stage 'Building'
-        slave {
-            withOpenshift {
-                withMaven(mavenImage: "openjdk:8", serviceAccount: "builder", mavenSettingsXmlSecret: 'm2-settings') {
-                    inside {
-                        stage('Prepare Environment') {
-                            createEnvironment(
-                                cloud: 'openshift', name: "${KUBERNETES_NAMESPACE}",
-                                environmentSetupScriptUrl: 'https://raw.githubusercontent.com/syndesisio/syndesis-system-tests/master/src/test/resources/setup.sh',
-                                environmentTeardownScriptUrl: 'https://raw.githubusercontent.com/syndesisio/syndesis-system-tests/master/src/test/resources/teardown.sh',
-                                waitForServiceList: ['syndesis-rest', 'syndesis-ui', 'syndesis-keycloak', 'syndesis-verifier'],
-                                waitTimeout: 600000L,
-                                namespaceDestroyEnabled: false,
-                                namespaceCleanupEnabled: false
-                            )
-                        }
+        stage('Building') {
+            slave {
+                withOpenshift {
+                    for (i = 0; i < cases.size; i++) {
+                        withMaven(cases[i].mavenSettings) {
+                            inside {
+                                stage('Prepare Environment') {
+                                    createEnvironment(
+                                        cloud: 'openshift', name: "${KUBERNETES_NAMESPACE}",
+                                        environmentSetupScriptUrl: 'https://raw.githubusercontent.com/syndesisio/syndesis-system-tests/master/src/test/resources/setup.sh',
+                                        environmentTeardownScriptUrl: 'https://raw.githubusercontent.com/syndesisio/syndesis-system-tests/master/src/test/resources/teardown.sh',
+                                        waitForServiceList: ['syndesis-rest', 'syndesis-ui', 'syndesis-keycloak', 'syndesis-verifier'],
+                                        waitTimeout: 600000L,
+                                        namespaceDestroyEnabled: false,
+                                        namespaceCleanupEnabled: false
+                                    )
+                                }
 
-                        stage('System Tests') {
-                            def testingNamespace = currentNamespace()
-                            test(component: 'syndesis-pipeline-library', envInitEnabled: false, namespace: "${KUBERNETES_NAMESPACE}", serviceAccount: 'jenkins')
+                                stage('System Tests') {
+                                    def testingNamespace = currentNamespace()
+                                    test(component: 'syndesis-pipeline-library', envInitEnabled: false, namespace: "${KUBERNETES_NAMESPACE}", serviceAccount: 'jenkins')
+                                }
+                            }
                         }
                     }
                 }

--- a/vars/withMaven.groovy
+++ b/vars/withMaven.groovy
@@ -21,7 +21,7 @@ def call(Map parameters = [:], body) {
     def workingDir = parameters.get('workingDir', '/home/jenkins')
     def mavenRepositoryClaim = parameters.get('mavenRepositoryClaim', '')
     def mavenSettingsXmlSecret = parameters.get('mavenSettingsXmlSecret', '')
-    def mavenSettingsXmlMountPath = parameters.get('mavenSettingsXmlMountPath', "/${workingDir}/.m2-ro")
+    def mavenSettingsXmlMountPath = parameters.get('mavenSettingsXmlMountPath', "/${workingDir}/.m2")
     def idleMinutes = parameters.get('idle', 10)
 
     def isPersistent = !mavenRepositoryClaim.isEmpty()
@@ -31,9 +31,9 @@ def call(Map parameters = [:], body) {
     envVars.add(containerEnvVar(key: 'MAVEN_OPTS', value: "-Duser.home=${workingDir} -Dmaven.repo.local=${workingDir}/.m2/repository/"))
 
     if (isPersistent) {
-        volumes.add(persistentVolumeClaim(claimName: "${mavenRepositoryClaim}", mountPath: "/${workingDir}/.m2"))
+        volumes.add(persistentVolumeClaim(claimName: "${mavenRepositoryClaim}", mountPath: "/${workingDir}/.m2/repository"))
     } else {
-        volumes.add(emptyDirVolume(mountPath: "/${workingDir}/.m2"))
+        volumes.add(emptyDirVolume(mountPath: "/${workingDir}/.m2/repository"))
     }
 
     if (hasSettingsXml) {
@@ -44,9 +44,6 @@ def call(Map parameters = [:], body) {
             idleMinutesStr: "${idleMinutes}",
             containers: [containerTemplate(name: 'maven', image: "${mavenImage}", command: '/bin/sh -c', args: 'cat', ttyEnabled: true, envVars: envVars)],
             volumes: volumes) {
-        if (hasSettingsXml) {
-            sh "cp -vfR ${mavenSettingsXmlMountPath}/* /${workingDir}/.m2/"
-        }
         body()
     }
 }

--- a/vars/withMaven.groovy
+++ b/vars/withMaven.groovy
@@ -31,9 +31,8 @@ def call(Map parameters = [:], body) {
     envVars.add(containerEnvVar(key: 'MAVEN_OPTS', value: "-Duser.home=${workingDir} -Dmaven.repo.local=${workingDir}/.m2/repository/"))
 
     if (isPersistent) {
+        // mount just the persisted repository cache
         volumes.add(persistentVolumeClaim(claimName: "${mavenRepositoryClaim}", mountPath: "/${workingDir}/.m2/repository"))
-    } else {
-        volumes.add(emptyDirVolume(mountPath: "/${workingDir}/.m2/repository"))
     }
 
     if (hasSettingsXml) {


### PR DESCRIPTION
This removes the workaround for mounting Maven settings to `.../.m2-ro`
and mounts to `.../.m2` as it used to be.