### PR TITLE
fix(build): bring back the `.m2-ro` idea

### DIFF
--- a/vars/inside.groovy
+++ b/vars/inside.groovy
@@ -1,7 +1,7 @@
 #!/usr/bin/groovy
 
 /**
- * Wraps teh code in a slave container.
+ * Wraps the code in a slave container.
  * @param parameters
  * @param body
  * @return
@@ -13,6 +13,11 @@ def call(Map parameters = [:], body) {
 
     slave(parameters) {
         node(label) {
+            sh '''
+                if [ -d $HOME/.m2-ro ]; then
+                    mkdir -p $HOME/.m2 && cp -vf $HOME/.m2-ro/* $HOME/.m2/
+                fi
+            '''
             body()
         }
     }

--- a/vars/withMaven.groovy
+++ b/vars/withMaven.groovy
@@ -21,7 +21,7 @@ def call(Map parameters = [:], body) {
     def workingDir = parameters.get('workingDir', '/home/jenkins')
     def mavenRepositoryClaim = parameters.get('mavenRepositoryClaim', '')
     def mavenSettingsXmlSecret = parameters.get('mavenSettingsXmlSecret', '')
-    def mavenSettingsXmlMountPath = parameters.get('mavenSettingsXmlMountPath', "/${workingDir}/.m2")
+    def mavenSettingsXmlMountPath = parameters.get('mavenSettingsXmlMountPath', "/${workingDir}/.m2-ro")
     def idleMinutes = parameters.get('idle', 10)
 
     def isPersistent = !mavenRepositoryClaim.isEmpty()


### PR DESCRIPTION
We need to mount the `m2-settings` kubernetes secret, if we mount it to
`.../.m2` then other files cannot written there as the directory is
owned by `root`. As a workaround let's mount it to `.../.m2-ro` and copy
the content over to `.../.m2`.